### PR TITLE
add route based code splitting / lazy loading

### DIFF
--- a/template/src/router/index.js
+++ b/template/src/router/index.js
@@ -1,6 +1,11 @@
 import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 import Router from 'vue-router'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-import Hello from '@/components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+
+const Hello = resolve => {
+  require.ensure(['@/components/Hello'], () => {
+    resolve(require('@/components/Hello'))
+  }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+}{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 Vue.use(Router){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 


### PR DESCRIPTION
As per #1 

> Code-splitting by default with vue-router

Lazy loading via routes requires these little tweaks in the router to make it work.
Webpack will now split off route based chunks and HTMLWebpackPlugin will add a prefetch script tag to the top of the HTML. Could possibly slow down performance very slightly in a small app like this, but I'll leave it to you to decide.

Vue docs that cover this: https://router.vuejs.org/en/advanced/lazy-loading.html

Ps. hi @cheneytsai 😃 
-conrad